### PR TITLE
add publish timeout

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -17,6 +17,7 @@ const assert = require('http-assert')
 const Session = require('./lib/session')
 const words = require('friendly-words')
 const P2P = require('@p2pcommons/sdk-js')
+const pTimeout = require('p-timeout')
 
 const stripe = createStripe(config.stripeSecretKey)
 const pool = new Pool()
@@ -129,10 +130,12 @@ const handler = async (req, res) => {
       const p2p = new P2P({
         baseDir: `/tmp/${Date.now()}-${Math.random()}`
       })
+      await p2p.ready()
+
       try {
-        await p2p.ready()
-        const mod = await p2p._getModule(key, version)
-        title = mod.metadata.title
+        ;({
+          metadata: { title }
+        } = await pTimeout(p2p._getModule(key, version), 5000))
       } finally {
         await p2p.destroy()
       }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -5446,6 +5446,21 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      },
+      "dependencies": {
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        }
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "mailgun-js": "^0.22.0",
     "mustache": "^4.0.0",
     "node-pg-migrate": "^4.2.1",
+    "p-timeout": "^3.2.0",
     "pg": "^7.17.0",
     "stripe": "^7.15.0"
   },


### PR DESCRIPTION
When publishing a module to the vault, we need to fetch the module's metadata from the swarm, in order to write title and other fields to the database. This operation needs to have a timeout, so if for some reason the module isn't available, the server doesn't keep trying forever.

The implementation of this timeout is currently blocked by https://github.com/p2pcommons/sdk-js/issues/85.

Once fixed, find a sensible timeout, maybe `20s`.