### PR TITLE
Update copyright year

### DIFF
--- a/.github/workflows/update-copyright-year.yml
+++ b/.github/workflows/update-copyright-year.yml
@@ -1,0 +1,16 @@
+name: Update copyright year(s) in license file
+
+on:
+  schedule:
+    - cron: "0 3 1 1 *"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: FantasticFiasco/action-update-license-year@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Liberate Science GmbH
+Copyright (c) 2020-2021 Liberate Science GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This bumps the copyright to the new year, plus adds a [github action](https://github.com/marketplace/actions/update-license-copyright-year-s#scenarios) to automatically do this at 3AM every year.

![](https://media.giphy.com/media/4TtTVTmBoXp8txRU0C/giphy.gif)