### PR TITLE
Add (empty) /api/delete route

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,6 +154,10 @@ const handler = async (req, res) => {
       ])
       break
     }
+    case 'GET /api/delete': {
+      json(res, [])
+      break
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds an `/api/delete` route. Closes #43.

Route in action on [`https://dev.vault.hypergraph.xyz/api/delete`](https://dev.vault.hypergraph.xyz/api/delete) (should return an empty Array).

![](https://media.giphy.com/media/yhdKi9jOYoNSE/giphy.gif)